### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ resources = AMGX.Resources(config)
 
 The different modes in AMGX are available as:
 
-- `AMGX.dDDI`
+- `AMGX.hDDI`
 - `AMGX.hDFI`
 - `AMGX.hFFI`
 - `AMGX.dDDI`


### PR DESCRIPTION
Duplicate `dDDI`. I presume one meant to be `hDDI`.