### PR TITLE
Initialize `libAMGX` only if `AMGX_jll.libamgxsh` is available

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AMGX"
 uuid = "c963dde9-0319-47f5-bf0c-b07d3c80ffa6"
 authors = ["Julia Computing"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 AMGX_jll = "656d14af-56e4-5275-8e68-4e861d7b5043"

--- a/src/AMGX.jl
+++ b/src/AMGX.jl
@@ -23,11 +23,13 @@ libAMGX = ""
 set_libAMGX_path(s::String) = (global libAMGX = s)
 
 function __init__()
-    amgx_dir = get(ENV, "JULIA_AMGX_PATH", nothing)
-    if amgx_dir !== nothing
-        set_libAMGX_path(amgx_dir)
-    else
-        set_libAMGX_path(AMGX_jll.libamgxsh)
+    if AMGX.AMGX_jll.is_available()
+        amgx_dir = get(ENV, "JULIA_AMGX_PATH", nothing)
+        if amgx_dir !== nothing
+            set_libAMGX_path(amgx_dir)
+        else
+            set_libAMGX_path(AMGX_jll.libamgxsh)
+        end
     end
 end
 


### PR DESCRIPTION
This PR conditionally initializes `libAMGX` so that `using AMGX` does not error on machines that do not have `AMGX_jll.libamgxsh`.

Closes #22